### PR TITLE
Changed prompt behaviour

### DIFF
--- a/deadfish.py
+++ b/deadfish.py
@@ -1,22 +1,29 @@
+import sys
+try:
+    sys.ps1
+except NameError:
+    sys.ps1 = '>>> '
+
 # Initialisation
 x = 0
 
 while True:
     # Get user input
-    cmd = raw_input(">> ")
+    cmd = raw_input(sys.ps1)
     if x == 256 or x == -1:
         # Overflow, reset accumulator
         x = 0
     # Process input
     if cmd == "i" or cmd == "x":
-        x = x + 1 # Increment
+        x += 1 # Increment
     elif cmd == "d":
-        x = x - 1 # Decrement
+        x -= 1 # Decrement
     elif cmd == "s" or cmd == "k":
-        x = x * x # Square
+        x **= 2 # Square
     elif cmd == "o" or cmd == "c":
         print x # Output
     elif cmd == "h":
         break # Halt
     else:
         print "Unrecognized command."
+


### PR DESCRIPTION
Now uses sys.ps1 if it already exists, resorting to ">>> " if not.
I also modified the addition, subtraction etc. to use the pythonic "add 1", "subtract 1" and "to the power of 2" operators.
(The newline at the bottom was GitHub's fault, but it makes the file look more *nix-y)
